### PR TITLE
Add address of s_playerViewmodelArmConfigs on windows

### DIFF
--- a/addons/sourcemod/gamedata/CustomPlayerArms.games.txt
+++ b/addons/sourcemod/gamedata/CustomPlayerArms.games.txt
@@ -11,6 +11,10 @@
 				{
 					"read"  "2"
 				}
+				"windows"
+				{
+					"read"  "18"
+				}
 			}
 		}
 		"Signatures"
@@ -19,6 +23,7 @@
 			{
 				"library"		"server"
 				"linux"			"\x55\xB8\x2A\x2A\x2A\x2A\x89\xE5\x57\x56\x53\x83\xEC\x1C\x8B\x7D\x08\x85\xFF\x74\x2A\x89\xC6"
+				"windows"		"\x53\x8B\xD9\x56\x57\x85\xDB\x2A\x2A\x33\xFF"
 			}
 		}
 	}


### PR DESCRIPTION
I guess windows version only have limited support is because of this. So I added the address. This is untested but should work. 